### PR TITLE
スクレイピング結果の保存フォーマットを変更

### DIFF
--- a/api/src/StoreWaitTime.js
+++ b/api/src/StoreWaitTime.js
@@ -1,8 +1,8 @@
 function doPost(e) {
     const params = JSON.parse(e.postData.getDataAsString());
     const keySortedList = makeKeySortedList(params)
-    const timeStamp = Math.round((new Date()).getTime() / 1000);
-    const writeTargetList = [ timeStamp ].concat(keySortedList)
+    const currentTime  = Utilities.formatDate(new Date(), 'Asia/Tokyo', 'yyyy/MM/dd HH:mm');
+    const writeTargetList = [ currentTime ].concat(keySortedList)
     writeToSpreadSheet(writeTargetList)
 }
 

--- a/scraping/src/sea/main.py
+++ b/scraping/src/sea/main.py
@@ -35,7 +35,8 @@ def post_spot_info(attractions_info, restaurants_info):
     headers = {"Content-Type": "application/json"}
     obj = {}
     for attraction in attractions_info:
-        obj[attraction.name] = attraction.wait_time + "," + attraction.enable
+        enable_str = "T" if attraction.enable == 1 else "F"
+        obj[attraction.name] = attraction.wait_time + "," + enable_str
     json_data = json.dumps(obj).encode("utf-8")
     request = urllib.request.Request(url, data=json_data, method=method, headers=headers)
     urllib.request.urlopen(request)  # todo:エラーハンドリング

--- a/scraping/src/sea/main.py
+++ b/scraping/src/sea/main.py
@@ -35,7 +35,7 @@ def post_spot_info(attractions_info, restaurants_info):
     headers = {"Content-Type": "application/json"}
     obj = {}
     for attraction in attractions_info:
-        obj[attraction.name] = attraction.wait_time
+        obj[attraction.name] = attraction.wait_time + "," + attraction.enable
     json_data = json.dumps(obj).encode("utf-8")
     request = urllib.request.Request(url, data=json_data, method=method, headers=headers)
     urllib.request.urlopen(request)  # todo:エラーハンドリング

--- a/scraping/src/sea/main.py
+++ b/scraping/src/sea/main.py
@@ -30,13 +30,13 @@ def fetch_realtime_restaurants_info(name_matching):
 
 
 def post_spot_info(attractions_info, restaurants_info):
-    url = "https://script.google.com/macros/s/AKfycbz_B_a0lg1Ialg0Gkvq3a_8aTs9D1Di04vnVnxXPCBQl5w3yld23bxr2JbPgwLrgtbT7g/exec"
+    url = "https://script.google.com/macros/s/AKfycbyTT3mi5BwhqPhyjoLra9d9ZR_HX7ewbkGJkvDGhO02dNUs1dBjW2Aa1sss-YHjY5VVGA/exec"
     method = "POST"
     headers = {"Content-Type": "application/json"}
     obj = {}
     for attraction in attractions_info:
-        enable_str = "T" if attraction.enable == 1 else "F"
-        obj[attraction.name] = attraction.wait_time + "," + enable_str
+        enable_str = "運営中" if attraction.enable == 1 else "停止中"
+        obj[attraction.name] = enable_str + "," + str(attraction.wait_time)
     json_data = json.dumps(obj).encode("utf-8")
     request = urllib.request.Request(url, data=json_data, method=method, headers=headers)
     urllib.request.urlopen(request)  # todo:エラーハンドリング


### PR DESCRIPTION
### 概要
* スクレイピング結果をスプレッドに保存する際の形式について、下記2点の変更を実施
  * 保存時の時刻をUnixタイムスタンプから `yyyyMMdd` 形式に変更
    * 単に見やすさのため
  * 「該当アトラクションが運営中か否か」の情報も合わせて保存する
    * 今のままだと、待ち時間が `-1` のときに下記を判別できないため
      * 運営していない
      * スタンバイパスが発券中
      * そもそも待ち時間が存在しないアトラクションである（フォートレス・エクスプロレーションなど）

### 検証
意図通りの形式で保存されることを確認
https://docs.google.com/spreadsheets/d/1GvymAJ57Il1dSbPGVeGv4PDwi6ymDs_MHfHDbosQFpc/edit#gid=0
* 36列を参照
* 37行目が元の形式になっているのは意図通り。このPRがmasterにマージされれば、すべて36行目の形式になる
<img width="922" alt="キャプチャ" src="https://user-images.githubusercontent.com/33785163/120098385-8e21a680-c170-11eb-9dce-512f3f03653d.PNG">
